### PR TITLE
Add release binary optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,10 @@ serde_json = "1.0.111"
 sha1 = "0.10.6"
 tokio = { version = "1.35.1", features = ["full"] }
 url = { version = "2.5.0", features = ["serde"] }
+
+[profile.release]
+codegen-units = 1
+opt-level = "z"
+strip = true
+lto = true
+panic = "abort"


### PR DESCRIPTION
This shrinks the release binary size from 3.9M to 1.3M.

Further improvements are possible building your own std, eg: 

```
rustup toolchain install nightly
rustup component add rust-src --toolchain nightly
```
and then:
```
$ RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target $(rustc -vV | grep host: | cut -d' ' -f2) --release
```

See https://github.com/johnthagen/min-sized-rust